### PR TITLE
fix missing worldevents locale keys

### DIFF
--- a/AtlasLoot/Locales/constants.en.lua
+++ b/AtlasLoot/Locales/constants.en.lua
@@ -1409,6 +1409,10 @@ if AL then
 	AL["Cracked Egg"] = true;
 	AL["Small Spice Bag"] = true;
 	AL["Handful of Candy"] = true;
+	AL["Clappers"] = true;
+	AL["Animals"] = true;
+	AL["Delicious buns"] = true;
+	AL["Trial"] = true;
 	AL["Lovely Dress Box"] = true;
 	AL["Dinner Suit Box"] = true;
 	AL["Bag of Heart Candies"] = true;

--- a/AtlasLoot/Locales/constants.ru.lua
+++ b/AtlasLoot/Locales/constants.ru.lua
@@ -2081,6 +2081,10 @@ if AL then
     AL["Cracked Egg"] = "Треснутое яйцо";
 	AL["Small Spice Bag"] = "Маленький мешочек со специями";
 	AL["Handful of Candy"] = "Пригоршня конфет";
+	AL["Clappers"] = "Хлопушки";
+	AL["Animals"] = "Питомцы и транспорт";
+	AL["Delicious buns"] = "Полезные мелочи";
+	AL["Trial"] = "Испытание";
 	AL["Lovely Dress Box"] = "Коробка с красивым платьем";
 	AL["Dinner Suit Box"] = "Коробка с вечерним костюмом";
 	AL["Bag of Heart Candies"] = "Пакетик с леденцами-сердечками";


### PR DESCRIPTION
Fix ruRU WorldEvents loading.
Add missing locale keys (`Clappers`, `Animals`, `Delicious buns`, `Trial`) required by `worldevents.lua`. Missing entries caused the WorldEvents module to stop loading early, so some event tables were never created.